### PR TITLE
Add powerup/powerdown function for ADF4350

### DIFF
--- a/include/mculib/adf4350.hpp
+++ b/include/mculib/adf4350.hpp
@@ -17,37 +17,42 @@ namespace ADF4350 {
 		int denominator = 32;
 		int O = 1;
 		int R = 1;
-		int rfPower = 0b01;
-		int auxPower = 0b00;
+		bool pdwn = false;
+		uint8_t rfPower = 0b01;
+		static constexpr int auxPower = 0b00;
 
 		// band select divider. 1 to 255.
-		int bsDivider = 255;
+		static constexpr int  bsDivider = 255;
 
 		// charge pump current, 0 to 15.
-		int cpCurrent = 15;
+		static constexpr int cpCurrent = 15;
 
 		// CLKDIV divider (for fastlock and phase resync). 0 to 4095.
-		int clkDivDivider = 6;
+		static constexpr int clkDivDivider = 6;
 
-		enum {
+		static constexpr enum {
 			CLKDIVMODE_OFF = 0b00,
 			CLKDIVMODE_FASTLOCK = 0b01,
 			CLKDIVMODE_RESYNC = 0b10
-		} clkDivMode;
+		} clkDivMode = CLKDIVMODE_OFF;
 
-		bool refDouble = false;
-		bool refDiv2 = false;
-		bool rfEnable = true;
-		bool auxEnable = false;
-		bool feedbackFromDivided = false;
-		bool lowSpurMode = true;
+		static constexpr bool refDouble = false;
+		static constexpr bool refDiv2 = false;
+		static constexpr bool rfEnable = true;
+		static constexpr bool auxEnable = false;
+		static constexpr bool feedbackFromDivided = false;
+		static constexpr bool lowSpurMode = true;
+		static constexpr int noiseMode = lowSpurMode ? 0b11 : 0b00;
+		static constexpr int refDbDivMode = (refDouble << 1) | (refDiv2 << 0);
 
 		ADF4350Driver(const sendWord_t& _sendWord): sendWord(_sendWord) {}
 
 
 		//odiv: output division factor, 1 to 16
 		void sendConfig() {
-			int odiv;
+			bool was_pwdn = pdwn;
+			pdwn = false; //Power down is no longer active.
+			uint8_t odiv;
 			switch(O) {
 				case 1:  odiv=0b000; break;
 				case 2:  odiv=0b001; break;
@@ -58,15 +63,10 @@ namespace ADF4350 {
 				case 64: odiv=0b110; break;
 				default: odiv = 0b000; break;
 			}
-			
-			int rfEn = rfEnable ? 1 : 0;
-			int auxEn = auxEnable ? 1 : 0;
-			int fb = feedbackFromDivided ? 0 : 1;
-			int noiseMode = lowSpurMode ? 0b11 : 0b00;
-			int refDbDivMode = 0b00;
-			if(refDouble) refDbDivMode |= 0b10;
-			if(refDiv2) refDbDivMode |= 0b01;
 
+			bool rfEn = rfEnable ? 1 : 0;
+			bool auxEn = auxEnable ? 1 : 0;
+			bool fb = feedbackFromDivided ? 0 : 1;
 
 			// reg 5
 			//        LD pin      register 5
@@ -75,15 +75,15 @@ namespace ADF4350 {
 			// reg 4
 			//        fb        rf divider       bs divider       aux en      aux pwr         rf en         rf pwr     register 4
 			sendWord((fb<<23) | (odiv<<20) 	| (bsDivider<<12) | (auxEn<<8) | (auxPower<<6) | (rfEn<<5) | (rfPower<<3) | 0b100);
-			
+
 			// reg 3
 			//           clkdiv mode             clkdiv           register 3
 			sendWord((int(clkDivMode)<<15) | (clkDivDivider<<3) | 0b011);
-			
+
 			// reg 2
-			//        low spur mode     muxout        reference db/div2      R          CP current    int-N    LDP     PD pol   register 2
-			sendWord((noiseMode<<29) | (0b001<<26) | (refDbDivMode << 24) | (R<<14) | (cpCurrent<<9) | (0<<8) | (0<<7) | (1<<6) | 0b010);
-			
+			//        low spur mode     muxout        reference db/div2      R          CP current    int-N    LDP     PD pol      powerdown  register 2
+			sendWord((noiseMode<<29) | (0b001<<26) | (refDbDivMode << 24) | (R<<14) | (cpCurrent<<9) | (0<<8) | (0<<7) | (1<<6) | (pdwn<<5) | 0b010);
+
 			// reg 1
 			//      prescaler   phase  frac modulus
 			sendWord((1<<27) | (0<<15) | (denominator<<3) | 0b001);
@@ -92,6 +92,21 @@ namespace ADF4350 {
 		// sets integer N and numerator
 		void sendN() {
 			sendWord((N<<15) | (numerator<<3));		//register 0
+		}
+
+		void sendPowerDown() {
+			if(pdwn == true)
+				return;
+			pdwn = true;
+			sendWord((noiseMode<<29) | (0b001<<26) | (refDbDivMode << 24) | (R<<14) | (cpCurrent<<9) | (0<<8) | (0<<7) | (1<<6) | (pdwn<<5) | 0b010);
+
+		}
+		void sendPowerUp() {
+			if(pdwn == false)
+				return;
+			pdwn = false;
+			sendWord((noiseMode<<29) | (0b001<<26) | (refDbDivMode << 24) | (R<<14) | (cpCurrent<<9) | (0<<8) | (0<<7) | (1<<6) | (pdwn<<5) | 0b010);
+
 		}
 	};
 


### PR DESCRIPTION
While at it make most configuration constant.
This is needed to allow powering down the ADF4350 when they are not needed.